### PR TITLE
Fix various picture upload issues

### DIFF
--- a/BeFake/BeFake.py
+++ b/BeFake/BeFake.py
@@ -23,7 +23,7 @@ class BeFake:
             proxies=proxies,
             verify=not disable_ssl,
             headers={
-                "user-agent": "AlexisBarreyat.BeReal/0.23.2 iPhone/16.0 hw/iPhone13_2",
+                "user-agent": "AlexisBarreyat.BeReal/0.24.0 iPhone/16.0.2 hw/iPhone12_8 (GTMSUF/1)",
                 "x-ios-bundle-identifier": "AlexisBarreyat.BeReal",
             },
         )

--- a/BeFake/models/picture.py
+++ b/BeFake/models/picture.py
@@ -32,7 +32,6 @@ class Picture(object):
         img_data = img_data.getvalue()
         if name is None:
             name = f"Photos/{befake.user_id}/bereal/{uuid.uuid4()}-{int(pendulum.now().timestamp())}{'-secondary' if secondary else ''}.webp"
-        print(name)
         json_data = {
             "cacheControl": "public,max-age=172800",
             "contentType": "image/webp",

--- a/BeFake/models/picture.py
+++ b/BeFake/models/picture.py
@@ -31,19 +31,19 @@ class Picture(object):
         img.save(img_data, format="JPEG", quality=90)
         img_data = img_data.getvalue()
         if name is None:
-            name = f"Photos/{befake.user_id}/{uuid.uuid4}-{int(pendulum.now().timestamp())}{'-secondary' if secondary else ''}.jpg"
-
+            name = f"Photos/{befake.user_id}/bereal/{uuid.uuid4()}-{int(pendulum.now().timestamp())}{'-secondary' if secondary else ''}.webp"
+        print(name)
         json_data = {
             "cacheControl": "public,max-age=172800",
-            "contentType": "image/jpeg",
+            "contentType": "image/webp",
             "metadata": {"type": "bereal"},
             "name": name,
         }
         headers = {
             "x-goog-upload-protocol": "resumable",
             "x-goog-upload-command": "start",
-            "x-firebase-storage-version": "ios/9.3.0",
-            "x-goog-upload-content-type": "image/jpeg",
+            "x-firebase-storage-version": "ios/9.4.0",
+            "x-goog-upload-content-type": "image/webp",
             "Authorization": f"Firebase {befake.token}",
             "x-goog-upload-content-length": str(len(img_data)),
             "content-type": "application/json",


### PR DESCRIPTION
The `uuid.uuid4` reference to generate a UUID for uploading a picture to Firebase is never actually called, just referenced, generating links containing text such as `<function+uuid4+at+0x101d7a280>`.