### PR TITLE
Fix parse-friends if a user has no profile picture

### DIFF
--- a/BeFake/__main__.py
+++ b/BeFake/__main__.py
@@ -116,14 +116,10 @@ def parse_friends():
         os.makedirs(f"{DATA_DIR}/friends/{friend.username}/info", exist_ok=True)
         os.makedirs(f"{DATA_DIR}/friends/{friend.username}/profile_pictures", exist_ok=True)
         friend.profile_picture.download()
-        info_data = {
-            "profile": friend.data_dict,
-            "photo": friend.profile_picture.metadata,
-        }
         with open(f"{DATA_DIR}/friends/{friend.username}/info/info{unix_timestamp()}.json", "w+") as f:
-            json.dump(info_data, f, indent=4)
+            json.dump(friend.data_dict, f, indent=4)
         with open(f"{DATA_DIR}/friends/{friend.username}/profile_pictures/{unix_timestamp()}.jpg", "wb") as f:
-            f.write(friend.profile_picture.data)
+                f.write(friend.profile_picture.data)
 
 @cli.command(help="Post the photos under /data/photos to your feed")
 def post():

--- a/BeFake/__main__.py
+++ b/BeFake/__main__.py
@@ -115,11 +115,12 @@ def parse_friends():
         os.makedirs(f"{DATA_DIR}/friends/{friend.username}", exist_ok=True)
         os.makedirs(f"{DATA_DIR}/friends/{friend.username}/info", exist_ok=True)
         os.makedirs(f"{DATA_DIR}/friends/{friend.username}/profile_pictures", exist_ok=True)
-        friend.profile_picture.download()
         with open(f"{DATA_DIR}/friends/{friend.username}/info/info{unix_timestamp()}.json", "w+") as f:
             json.dump(friend.data_dict, f, indent=4)
-        with open(f"{DATA_DIR}/friends/{friend.username}/profile_pictures/{unix_timestamp()}.jpg", "wb") as f:
-                f.write(friend.profile_picture.data)
+
+        if friend.profile_picture.exists():
+            with open(f"{DATA_DIR}/friends/{friend.username}/profile_pictures/{unix_timestamp()}.jpg", "wb") as f:
+                f.write(friend.profile_picture.download())
 
 @cli.command(help="Post the photos under /data/photos to your feed")
 def post():

--- a/BeFake/models/picture.py
+++ b/BeFake/models/picture.py
@@ -16,6 +16,9 @@ class Picture(object):
     def __repr__(self) -> str:
         return f"<Image {self.url} {self.width}x{self.height}>"
 
+    def exists(self):
+        return self.url is not None
+    
     def download(self):
         r = httpx.get(self.url)
         self.data = r.content

--- a/BeFake/models/picture.py
+++ b/BeFake/models/picture.py
@@ -18,7 +18,6 @@ class Picture(object):
 
     def download(self):
         r = httpx.get(self.url)
-        self.metadata = {header: r.headers[header] for header in r.headers.keys()}
         self.data = r.content
         return r.content
 


### PR DESCRIPTION
Previously, the script would crash when it encountered a user without a profile picture.
I have also deleted `pciture.metadata` ([this line](https://github.com/notmarek/BeFake/commit/5628550cc4b8e6d91d9b1d81056545d0dbb045e5#diff-1c8e4cdae74bff5fb0c6dc07758f15e3d8638301f367969e56d5ab9923c7f93aR21)), because I couldn't find any useful information in it. Afterall, it's just a bunch of headers form a request. This way it was easier to fix the issue by a few lines.