### PR TITLE
Make application installable via pip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .venv
+.idea/
 __pycache__
 token.txt
 feeds

--- a/BeFake/BeFake.py
+++ b/BeFake/BeFake.py
@@ -3,12 +3,12 @@ import json
 import httpx
 import pendulum
 import hashlib
-from models.picture import Picture
-from models.realmoji_picture import RealmojiPicture
+from .models.picture import Picture
+from .models.realmoji_picture import RealmojiPicture
 
-from models.post import Post
-from models.memory import Memory
-from models.user import User
+from .models.post import Post
+from .models.memory import Memory
+from .models.user import User
 
 
 class BeFake:
@@ -336,7 +336,7 @@ class BeFake:
         }
         res = self.client.post("https://us-central1-alexisbarreyat-bereal.cloudfunctions.net/sendRealMoji", json=json_data, headers={"authorization": f"Bearer {self.token}"})
         return res.json()
-    
+
     # works also for not friends and unpublic post with given post_id
     def get_reactions(self, post_id):
         payload = {

--- a/BeFake/__main__.py
+++ b/BeFake/__main__.py
@@ -1,8 +1,8 @@
 import json
 import os
-from BeFake import BeFake
-from models.realmoji_picture import RealmojiPicture
-from utils import *
+from .BeFake import BeFake
+from .models.realmoji_picture import RealmojiPicture
+from .utils import *
 
 import click
 import httpx

--- a/README.md
+++ b/README.md
@@ -5,9 +5,18 @@
 
 A cool tool for collecting all your friends photos from BeReal (including RealMojis) without taking any screenshots or even opening the app.
 
-
+## Install
+```bash
+pip install git+https://github.com/notmarek/BeFake
+```
 
 ## Usage
+```bash
+befake [OPTIONS] COMMAND [ARGS]...
+```
+
+
+## Developement
 
 
 ```bash
@@ -15,7 +24,7 @@ A cool tool for collecting all your friends photos from BeReal (including RealMo
   source .venv/bin/activate
 
   pip install -r requirements.txt
-  python BeFake
+  python befake.py
 ```
 
 have fun

--- a/befake.py
+++ b/befake.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+from BeFake.__main__ import cli
+
+if __name__ == '__main__':
+    cli()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,29 @@
+import setuptools
+
+setuptools.setup(
+    name='BeFake',
+    version='1.0.0',
+    description='BeReal Python API wrapper',
+    long_description=open('README.md').read(),
+    url='https://github.com/notmarek/BeFake',
+    author='Marek Veselý',
+    license='Unlicense',
+    entry_points={'console_scripts': ['befake=BeFake.__main__:cli']},
+    packages=setuptools.find_packages(),
+    install_requires=[line.strip() for line in open("requirements.txt").readlines()],
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Environment :: Console',
+        'Intended Audience :: End Users/Desktop',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3 :: Only',
+        'Topic :: Internet',
+        'Topic :: Multimedia :: Graphics'
+    ],
+)


### PR DESCRIPTION
Please read my changes in README.md! You have to use a different command to launch befake from the current working directory. 
Perviously: `python BeFake`
Now: `python befake.py`

If you install via pip, then you can start BeFake from any directory using the `befake` command.

Also, it'd be really cool if you could publish the project on [pypi.org](https://pypi.org). Would make depending on the project (and updating it and launching it from a custom directory) a lot easier.

Also, I've added `.idea/` to .gitigore because it was bothering me.