### PR TITLE
possibility to constantly download changes to feed

### DIFF
--- a/BeFake/BeFake.py
+++ b/BeFake/BeFake.py
@@ -152,14 +152,17 @@ class BeFake:
         )
         return res.json()
 
-    def get_friends_feed(self):
+    def get_friends_feed(self, raw=False):
         res = self.client.get(
             f"{self.api_url}/feeds/friends",
             headers={
                 "authorization": self.token,
             },
         ).json()
+        if raw:
+            return res
         return [Post(p, self) for p in res]
+    
 
     def get_discovery_feed(self):
         res = self.client.get(


### PR DESCRIPTION
Just like the App does (monitored with proxy), the infinite_reload command gets the friends feed every few (5) seconds and downloads everything, if something has changed. Every 100 requests, the function refreshes the token.

Not yet implemented, but could be cool: Save the raw feed data and download everything into a new directory with a unix timestamp in its name, everytime something changes.