### PR TITLE
updated Picture model to download images in .jpg, instead of default .webp

### DIFF
--- a/BeFake/models/screenshot_v2.py
+++ b/BeFake/models/screenshot_v2.py
@@ -5,7 +5,7 @@ class ScreenshotV2(object):
     def __init__(self, data_dict, befake) -> None:
         self.bf = befake
         self.id = data_dict.get("id", None)
-        self.snapped_at = pendulum.parse(data_dict.get("snappedAt", None)) # string in format 'YYYY-MM-DDTHH:MM:SS.621Z'
+        self.snapped_at = pendulum.parse(data_dict.get("snappedAt", None))  # string in format YYYY-MM-DDTHH:mm:ss.sssZ
         self.user = User(data_dict.get("user", None), befake)
 
     def __repr__(self) -> str:


### PR DESCRIPTION
sometime in the last month, the bereal's image extension changed from jpg to webp, so this uses Pillow to download images in any format, with the default being jpg. It doesn't increase the quality of the image, just increases compatibility.

webp 🤮