### PR TITLE
Add decorator for loading the BeFake object

### DIFF
--- a/BeFake/BeFake.py
+++ b/BeFake/BeFake.py
@@ -143,7 +143,7 @@ class BeFake:
     def get_user_profile(self, user_id):
         # here for example we have a firebase-instance-id-token header with the value from the next line, that we can just ignore (but maybe we need it later, there seem to be some changes to the API especially endpoints moving tho the cloudfunctions.net server)
         # cTn8odwxQo6DR0WFVnM9TJ:APA91bGV86nmQUkqnLfFv18IhpOak1x02sYMmKvpUAqhdfkT9Ofg29BXKXS2mbt9oE-LoHiiKViXw75xKFLeOxhb68wwvPCJF79z7V5GbCsIQi7XH1RSD8ItcznqM_qldSDjghf5N8Uo
-        res = self.client.get(f"https://mobile.bereal.com/api/person/profiles/{user_id}",
+        res = self.client.get(f"{self.api_url}/person/profiles/{user_id}",
                                headers={"authorization": f"Bearer {self.token}"}).json()
         return User(res, self)
 


### PR DESCRIPTION
This gets rid of the repetitious
```python
bf = BeFake()
try:
    bf.load()
except:
    raise Exception("No token found, are you logged in?")
```
by moving it into a decorator `load_bf`.

On a side note, I don't like how _any_ exception raised in `bf.load()` will print `No token found`, even if `token.txt` actually exists, but `refresh_tokens()` fails. But that's for another PR.

Oh, and I sneaked [1c40f26](https://github.com/notmarek/BeFake/pull/53/commits/1c40f26f19d84485458652b6c2ccd6bc13d36974) into this. Of course, I can move it to another PR if you prefer that.