### PR TITLE
Fixed 'old-post' post error 400

### DIFF
--- a/BeFake/models/post.py
+++ b/BeFake/models/post.py
@@ -68,7 +68,7 @@ class Post(object):
             taken_at=None
     ):
         if taken_at is None:
-            now = pendulum.now()
+            now = pendulum.now(tz="UTC")
             taken_at = f"{now.to_date_string()}T{now.to_time_string()}Z"
 
         postUpload = PostUpload(primary, secondary, resize)


### PR DESCRIPTION
I live in PST time zone and was constantly getting 'old-post' errors. I found this issue to be caused by the timestamp generated by pendulum.now() being automatically set to my local time zone. I specified UTC time zone and it fixed the issues. This could also be the solution to issue #61.