### PR TITLE
Login overhaul + fixup

### DIFF
--- a/BeFake/__main__.py
+++ b/BeFake/__main__.py
@@ -73,6 +73,13 @@ def login(phone_number, deviceid, backend):
     print("You can now try to use the other commands ;)")
 
 
+@cli.command(help="Get a new access_token from your old token.txt config file")
+def legacy_token():
+    bf = BeFake()
+    bf.legacy_load()
+    bf.save()
+    print("Successful token import, you can now use the other commands!")
+
 @cli.command(help="Get info about your account")
 @load_bf
 def me(bf):


### PR DESCRIPTION
This is sadly breaking and adds two new tokens: an access_token for mobile.bereal.com and a firebase_token that is used to get user info and later maybe push notifications. I think we can avoid that by storing our user_id inside of the json config. I've closely replicated the login process on Android, maybe some unnecessary requests can be removed.


- [x]  Vonage backend
- [x] reCAPTCHA backend
- [x] iOS client_secret for vonage