### PR TITLE
fix: click.echo takes msg as first parameter

### DIFF
--- a/BeFake/__main__.py
+++ b/BeFake/__main__.py
@@ -131,10 +131,10 @@ def feed(bf, feed_id, save_location, realmoji_location, instant_realmoji_locatio
 
     for item in feed:
         if feed_id == "memories":
-            click.echo("saving memory ".format(item.memory_day))
+            click.echo(f"saving memory {}".format(item.memory_day))
             _save_location = save_location.format(date=item.memory_day)
         else:
-            click.echo(f"saving post by {item.user.username}".ljust(50, " ") + f"{item.id}")
+            click.echo(f"saving post by {item.user.username}".ljust(50, " ") + item.id)
             post_date = item.creation_date.format(date_format)
             _save_location = save_location.format(user=item.user.username, date=post_date, feed_id=feed_id,
                                                   post_id=item.id)

--- a/BeFake/__main__.py
+++ b/BeFake/__main__.py
@@ -131,7 +131,7 @@ def feed(bf, feed_id, save_location, realmoji_location, instant_realmoji_locatio
 
     for item in feed:
         if feed_id == "memories":
-            click.echo(f"saving memory {}".format(item.memory_day))
+            click.echo("saving memory {}".format(item.memory_day))
             _save_location = save_location.format(date=item.memory_day)
         else:
             click.echo(f"saving post by {item.user.username}".ljust(50, " ") + item.id)

--- a/BeFake/__main__.py
+++ b/BeFake/__main__.py
@@ -92,7 +92,7 @@ def me(bf):
 @load_bf
 def refresh(bf):
     bf.refresh_tokens()
-    click.echo(bf.token, end='', flush=True)
+    click.echo(bf.token, nl=False)
     bf.save()
 
 
@@ -131,10 +131,10 @@ def feed(bf, feed_id, save_location, realmoji_location, instant_realmoji_locatio
 
     for item in feed:
         if feed_id == "memories":
-            click.echo("saving memory", item.memory_day)
+            click.echo("saving memory ".format(item.memory_day))
             _save_location = save_location.format(date=item.memory_day)
         else:
-            click.echo(f"saving post by {item.user.username}".ljust(50, " "), f"{item.id}")
+            click.echo(f"saving post by {item.user.username}".ljust(50, " ") + f"{item.id}")
             post_date = item.creation_date.format(date_format)
             _save_location = save_location.format(user=item.user.username, date=post_date, feed_id=feed_id,
                                                   post_id=item.id)


### PR DESCRIPTION
Last commit changed print to click.echo, but a couple of the print statements used multiple arguments for the string which
click.echo doesn't support.