### PR TITLE
Fix saving after token refresh

### DIFF
--- a/BeFake/__main__.py
+++ b/BeFake/__main__.py
@@ -94,9 +94,12 @@ def me(bf):
 @cli.command(help="Refresh token")
 @load_bf
 def refresh(bf):
+    # If the token has expired, bf.refresh_tokens() will also get called by @load_bf.
+    # In that scenario, a double refresh will be done.
+    # Since this command is mostly used for debugging, it wouldn't be practical to add extra code to prevent this
+    # behaviour.
     bf.refresh_tokens()
     click.echo(bf.token, nl=False)
-    bf.save()
 
 
 @cli.command(help="Download a feed")


### PR DESCRIPTION
I really hope that this was the last problem with refreshes.

Basically, in https://github.com/notmarek/BeFake/pull/91 I've (rightfully) added a save command to the end of refresh_tokens(), however, that was called before firebase tokens were loaded, so the save() command failed with an AttributeError.

Fixes https://github.com/notmarek/BeFake/issues/89
Fixes https://github.com/notmarek/BeFake/issues/94